### PR TITLE
Use Darkvision instead of Basic Vision for tokens that cannot see in the dark

### DIFF
--- a/script.js
+++ b/script.js
@@ -141,8 +141,8 @@ function updateTokens(actor, { force = false } = {}) {
     } else if (modes.darkvision && (sight.visionMode !== "darkvision" || sight.range !== modes.darkvision)) {
       const defaults = CONFIG.Canvas.visionModes.darkvision.vision.defaults;
       updates.sight = { visionMode: "darkvision", ...defaults, range: modes.darkvision };
-    } else if (!canSeeInDark && token.sight.visionMode !== "basic" && token.sight.range !== null) {
-      updates.sight = { visionMode: "basic", contrast: 0, brightness: 0, saturation: 0, range: null };
+    } else if (!canSeeInDark && (token.sight.visionMode !== "darkvision" || token.sight.range !== null)) {
+      updates.sight = { visionMode: "darkvision", contrast: 0, brightness: 0, saturation: 0, range: null };
     }
 
     // Blindsight


### PR DESCRIPTION
Tokens that cannot see in the dark can enjoy the fog of war in color while tokens with darkvision cannot. To make it fair tokens without darkvision should use the Darkvision mode too. Adequate Vision's Darkvision mode doesn't boost dim to bright light; if it did, we would need to adjust Basic Vision to be desaturated or create a separate vision mode for tokens that cannot see in the dark.