### PR TITLE
Use See All detection mode for Truesight

### DIFF
--- a/script.js
+++ b/script.js
@@ -157,7 +157,7 @@ function updateTokens(actor, { force = false } = {}) {
       const range = Math.max(modes.truesight, modes.devilsSight ?? 0);
       updates.sight = { visionMode: "devilsSight", ...defaults, range };
       updates.detectionModes ??= [];
-      updates.detectionModes.push({ id: "seeInvisibility", enabled: true, range: modes.truesight });
+      updates.detectionModes.push({ id: "seeAll", enabled: true, range: modes.truesight });
     }
 
     // Tremorsense


### PR DESCRIPTION
See All is essentially truesight and technically truesight doesn't give the creature See Invisibility, it just ignores the invisible condition too. This changes doesn't really make a difference without Perfect Vision; but with Perfect Vision it allows the user to set vision limits for See Invisibility and Truesight (See All) separately (#5).