### PR TITLE
Change See Invisibility to be unaffected by the blinded status

### DIFF
--- a/script.js
+++ b/script.js
@@ -226,11 +226,8 @@ class InvisibilityDetectionMode extends DetectionMode {
 
   /** @override */
   _canDetect(visionSource, target) {
-    const source = visionSource.object;
-
-    // Only invisible tokens can be detected; the vision source must not be blinded
+    // Only invisible tokens can be detected
     return (
-      !(source instanceof Token && source.document.hasStatusEffect(CONFIG.specialStatusEffects.BLIND)) &&
       target instanceof Token &&
       target.document.hasStatusEffect(CONFIG.specialStatusEffects.INVISIBLE)
     );


### PR DESCRIPTION
It doesn't really make a difference at the moment, because all sight-based detection modes do not work if blinded. But in theory there could be a sight-based detection mode that isn't affected by blindness for some reason, which then could detect an invisible creature with See Invisibility. Therefore See Invisibility shouldn't make the decision to not test for visibility if blinded.