### PR TITLE
Restrict Blindsight by total cover instead of line of sight

### DIFF
--- a/script.js
+++ b/script.js
@@ -184,6 +184,15 @@ function updateTokens(actor, { force = false } = {}) {
   }
 }
 
+const TOTAL_COVER_TYPE = Symbol();
+
+Object.defineProperty(WallDocument.prototype, TOTAL_COVER_TYPE, {
+  get() {
+    // A wall provides total cover if it restricts at least one of the senses
+    return Math.max(this.move, this.light, this.sight, this.sound);
+  }
+});
+
 class BlindDetectionMode extends DetectionMode {
   constructor() {
     super({
@@ -205,7 +214,17 @@ class BlindDetectionMode extends DetectionMode {
 
   /** @override */
   _canDetect(visionSource, target) {
-    return target instanceof Token || target instanceof DoorControl;
+    return true;
+  }
+
+  /** @override */
+  _testLOS(visionSource, mode, target, test) {
+    // Blindsight is restricted by total cover
+    return !CONFIG.Canvas.losBackend.testCollision(
+      { x: visionSource.x, y: visionSource.y },
+      test.point,
+      { type: TOTAL_COVER_TYPE, mode: "any", source: visionSource }
+    );
   }
 }
 

--- a/script.js
+++ b/script.js
@@ -189,7 +189,7 @@ class BlindDetectionMode extends DetectionMode {
     super({
       id: "blindsight",
       label: "Blindsight",
-      type: DetectionMode.DETECTION_TYPES.SIGHT,
+      type: DetectionMode.DETECTION_TYPES.OTHER,
     });
   }
 

--- a/script.js
+++ b/script.js
@@ -184,15 +184,6 @@ function updateTokens(actor, { force = false } = {}) {
   }
 }
 
-const TOTAL_COVER_TYPE = Symbol();
-
-Object.defineProperty(WallDocument.prototype, TOTAL_COVER_TYPE, {
-  get() {
-    // A wall provides total cover if it restricts at least one of the senses
-    return Math.max(this.move, this.light, this.sight, this.sound);
-  }
-});
-
 class BlindDetectionMode extends DetectionMode {
   constructor() {
     super({
@@ -223,7 +214,7 @@ class BlindDetectionMode extends DetectionMode {
     return !CONFIG.Canvas.losBackend.testCollision(
       { x: visionSource.x, y: visionSource.y },
       test.point,
-      { type: TOTAL_COVER_TYPE, mode: "any", source: visionSource }
+      { type: "move", mode: "any", source: visionSource }
     );
   }
 }


### PR DESCRIPTION
Blindsight is not sight-based. It could be sound-based if it's echolocation but Blindsight could also be thermal vision or smell. That's why the `OTHER` type is the best fit, I'd say.

Blindsight is restricted by total cover, meaning if the path to the point is obstructed in some way, it's total cover, even if can see through it. I defined total cover in terms of the other wall restrictions: if the wall isn't completely unrestricted, it's assumed to provide total cover. Because 4 collision checks wouldn't be particularly great for performance, I defined a new wall type. This isn't officially supported, but it works flawlessly.