### PR TITLE
More improvements

### DIFF
--- a/script.js
+++ b/script.js
@@ -35,6 +35,8 @@ Hooks.once("init", () => {
   CONFIG.Canvas.detectionModes.blindsight = new BlindDetectionMode();
   CONFIG.Canvas.detectionModes.devilsSight = new DevilsSightDetectionMode();
   CONFIG.Canvas.detectionModes.echolocation = new EcholocationDetectionMode();
+  CONFIG.Canvas.detectionModes.feelTremor.updateSource({ label: "DND5E.SenseTremorsense" });
+  CONFIG.Canvas.detectionModes.seeAll.updateSource({ label: "DND5E.SenseTruesight" });
   CONFIG.Canvas.detectionModes.seeInvisibility = new InvisibilityDetectionMode();
 
   CONFIG.specialStatusEffects.DEAF = "deaf";
@@ -245,7 +247,7 @@ class BlindDetectionMode extends DetectionMode {
   constructor() {
     super({
       id: "blindsight",
-      label: "Blindsight",
+      label: "DND5E.SenseBlindsight",
       type: DetectionMode.DETECTION_TYPES.SIGHT,
     });
   }

--- a/script.js
+++ b/script.js
@@ -46,7 +46,7 @@ Hooks.once("init", () => {
 Hooks.once("setup", () => {
   game.settings.register("adequate-vision", "linkActorSenses", {
     name: "Link Actor Senses (In Testing!)",
-    hint: "Automatically manage vision/detection modes according to the senses possessed by each token's corresponding actor.",
+    hint: "Automatically manage vision/detection modes according to the senses possessed by each token's corresponding actor. Currently only supported for PCs.",
     scope: "world",
     config: true,
     default: true,
@@ -67,7 +67,8 @@ Hooks.on("canvasReady", () => {
 
 // Update token sources when an actor's senses are updated
 Hooks.on("updateActor", (actor, changes, context, userId) => {
-  if (hasProperty(changes, "system.attributes.senses")) {
+  const hasSensesUpdate = Object.keys(flattenObject(changes)).some((c) => c.startsWith("system.attributes.senses"));
+  if (hasSensesUpdate) {
     updateTokens(actor);
   }
 });
@@ -99,7 +100,9 @@ Hooks.on("createToken", (token, context, userId) => {
 });
 Hooks.on("updateToken", (token, changes, context, userId) => {
   if (!token.actor) return;
-  if ("sight" in changes || "detectionModes" in changes) {
+
+  const changesKeys = Object.keys(flattenObject(changes));
+  if (changesKeys.some((k) => k.startsWith("sight") || k.startsWith("detectionModes"))) {
     updateTokens(token.actor);
   }
 });
@@ -176,36 +179,35 @@ function updateTokens(actor, { force = false } = {}) {
   const tokens = actor.getActiveTokens(false, true).filter((t) => t.sight.enabled);
   for (const token of tokens) {
     const updates = {};
+    const { sight, detectionModes } = token;
+    const canSeeInDark = ["darkvision", "devilsSight", "truesight"].some((m) => !!modes[m]);
 
     // VISION MODES
 
-    if (modes.devilsSight || modes.truesight) {
+    if (modes.devilsSight && (sight.visionMode !== "devilsSight" || sight.range !== modes.devilsSight)) {
       const defaults = CONFIG.Canvas.visionModes.devilsSight.vision.defaults;
-      const range = Math.max(modes.truesight ?? 0, modes.devilsSight ?? 0);
-      updates.sight = { visionMode: "devilsSight", ...defaults, range };
-    } else if (modes.darkvision) {
+      updates.sight = { visionMode: "devilsSight", ...defaults };
+    } else if (modes.darkvision && (sight.visionMode !== "darkvision" || sight.range !== modes.darkvision)) {
       const defaults = CONFIG.Canvas.visionModes.darkvision.vision.defaults;
       updates.sight = { visionMode: "darkvision", ...defaults, range: modes.darkvision };
-    } else {
-      const defaults = CONFIG.Canvas.visionModes.basic.vision.defaults;
-      updates.sight = { visionMode: "basic", ...defaults, range: 0 };
+    } else if (!canSeeInDark && token.sight.visionMode !== "basic" && token.sight.range !== null) {
+      updates.sight = { visionMode: "basic", contrast: 0, brightness: 0, saturation: 0, range: null };
     }
-
-    // Don't override vision tint and attenuation set by the user
-    delete updates.sight.attenuation;
-    delete updates.sight.color
 
     // DETECTION MODES
 
-    updates.detectionModes = [];
-
     // Devil's sight
     if (modes.devilsSight) {
+      updates.detectionModes ??= [];
       updates.detectionModes.push({ id: "devilsSight", enabled: true, range: modes.devilsSight });
     }
 
     // Truesight
-    if (modes.truesight) {
+    if (modes.truesight && sight.visionMode !== "devilsSight") {
+      const defaults = CONFIG.Canvas.visionModes.devilsSight.vision.defaults;
+      const range = Math.max(modes.truesight, modes.devilsSight ?? 0);
+      updates.sight = { visionMode: "devilsSight", ...defaults, range };
+      updates.detectionModes ??= [];
       updates.detectionModes.push({ id: "seeAll", enabled: true, range: modes.truesight });
     }
 
@@ -216,24 +218,30 @@ function updateTokens(actor, { force = false } = {}) {
 
     // Blindsight
     if (modes.blindsight) {
+      updates.detectionModes ??= [];
       updates.detectionModes.push({ id: "blindsight", enabled: true, range: modes.blindsight });
     }
 
     // Echolocation
     if (modes.echolocation) {
+      updates.detectionModes ??= [];
       updates.detectionModes.push({ id: "echolocation", enabled: true, range: modes.echolocation });
     }
 
     // Tremorsense
     if (modes.tremorsense) {
-      updates.detectionModes.push({ id: "feelTremor", enabled: true, range: modes.tremorsense });
+      const hasFeelTremor = detectionModes.some((m) => m.id === "feelTremor" && m.range === mode.tremorsense);
+      if (!hasFeelTremor) {
+        updates.detectionModes ??= [];
+        updates.detectionModes.push({ id: "feelTremor", enabled: true, range: modes.tremorsense });
+      }
+    } else if (detectionModes.some((m) => m.id === "feelTremor")) {
+      updates.detectionModes = token._source.detectionModes.filter((m) => m.id !== "feelTremor");
     }
 
-    // Note: At the moment (10.288) `updateSource` doesn't return the correct diff (#8503).
-    // So we need to diff `updates` with the source data ourselves until it's fixed.
-    const changes = diffObject(token.toObject(), updates);
-    if (!isEmpty(changes)) {
-      token.updateSource(changes);
+    // Update?
+    if (Object.keys(updates).length > 0) {
+      token.updateSource(updates);
       madeUpdates = true;
     }
   }

--- a/script.js
+++ b/script.js
@@ -46,7 +46,7 @@ Hooks.once("init", () => {
 Hooks.once("setup", () => {
   game.settings.register("adequate-vision", "linkActorSenses", {
     name: "Link Actor Senses (In Testing!)",
-    hint: "Automatically manage vision/detection modes according to the senses possessed by each token's corresponding actor. Currently only supported for PCs.",
+    hint: "Automatically manage vision/detection modes according to the senses possessed by each token's corresponding actor.",
     scope: "world",
     config: true,
     default: true,
@@ -67,8 +67,7 @@ Hooks.on("canvasReady", () => {
 
 // Update token sources when an actor's senses are updated
 Hooks.on("updateActor", (actor, changes, context, userId) => {
-  const hasSensesUpdate = Object.keys(flattenObject(changes)).some((c) => c.startsWith("system.attributes.senses"));
-  if (hasSensesUpdate) {
+  if (hasProperty(changes, "system.attributes.senses")) {
     updateTokens(actor);
   }
 });
@@ -100,9 +99,7 @@ Hooks.on("createToken", (token, context, userId) => {
 });
 Hooks.on("updateToken", (token, changes, context, userId) => {
   if (!token.actor) return;
-
-  const changesKeys = Object.keys(flattenObject(changes));
-  if (changesKeys.some((k) => k.startsWith("sight") || k.startsWith("detectionModes"))) {
+  if ("sight" in changes || "detectionModes" in changes) {
     updateTokens(token.actor);
   }
 });
@@ -179,35 +176,36 @@ function updateTokens(actor, { force = false } = {}) {
   const tokens = actor.getActiveTokens(false, true).filter((t) => t.sight.enabled);
   for (const token of tokens) {
     const updates = {};
-    const { sight, detectionModes } = token;
-    const canSeeInDark = ["darkvision", "devilsSight", "truesight"].some((m) => !!modes[m]);
 
     // VISION MODES
 
-    if (modes.devilsSight && (sight.visionMode !== "devilsSight" || sight.range !== modes.devilsSight)) {
+    if (modes.devilsSight || modes.truesight) {
       const defaults = CONFIG.Canvas.visionModes.devilsSight.vision.defaults;
-      updates.sight = { visionMode: "devilsSight", ...defaults };
-    } else if (modes.darkvision && (sight.visionMode !== "darkvision" || sight.range !== modes.darkvision)) {
+      const range = Math.max(modes.truesight ?? 0, modes.devilsSight ?? 0);
+      updates.sight = { visionMode: "devilsSight", ...defaults, range };
+    } else if (modes.darkvision) {
       const defaults = CONFIG.Canvas.visionModes.darkvision.vision.defaults;
       updates.sight = { visionMode: "darkvision", ...defaults, range: modes.darkvision };
-    } else if (!canSeeInDark && token.sight.visionMode !== "basic" && token.sight.range !== null) {
-      updates.sight = { visionMode: "basic", contrast: 0, brightness: 0, saturation: 0, range: null };
+    } else {
+      const defaults = CONFIG.Canvas.visionModes.basic.vision.defaults;
+      updates.sight = { visionMode: "basic", ...defaults, range: 0 };
     }
+
+    // Don't override vision tint and attenuation set by the user
+    delete updates.sight.attenuation;
+    delete updates.sight.color
 
     // DETECTION MODES
 
+    updates.detectionModes = [];
+
     // Devil's sight
     if (modes.devilsSight) {
-      updates.detectionModes ??= [];
       updates.detectionModes.push({ id: "devilsSight", enabled: true, range: modes.devilsSight });
     }
 
     // Truesight
-    if (modes.truesight && sight.visionMode !== "devilsSight") {
-      const defaults = CONFIG.Canvas.visionModes.devilsSight.vision.defaults;
-      const range = Math.max(modes.truesight, modes.devilsSight ?? 0);
-      updates.sight = { visionMode: "devilsSight", ...defaults, range };
-      updates.detectionModes ??= [];
+    if (modes.truesight) {
       updates.detectionModes.push({ id: "seeAll", enabled: true, range: modes.truesight });
     }
 
@@ -218,30 +216,24 @@ function updateTokens(actor, { force = false } = {}) {
 
     // Blindsight
     if (modes.blindsight) {
-      updates.detectionModes ??= [];
       updates.detectionModes.push({ id: "blindsight", enabled: true, range: modes.blindsight });
     }
 
     // Echolocation
     if (modes.echolocation) {
-      updates.detectionModes ??= [];
       updates.detectionModes.push({ id: "echolocation", enabled: true, range: modes.echolocation });
     }
 
     // Tremorsense
     if (modes.tremorsense) {
-      const hasFeelTremor = detectionModes.some((m) => m.id === "feelTremor" && m.range === mode.tremorsense);
-      if (!hasFeelTremor) {
-        updates.detectionModes ??= [];
-        updates.detectionModes.push({ id: "feelTremor", enabled: true, range: modes.tremorsense });
-      }
-    } else if (detectionModes.some((m) => m.id === "feelTremor")) {
-      updates.detectionModes = token._source.detectionModes.filter((m) => m.id !== "feelTremor");
+      updates.detectionModes.push({ id: "feelTremor", enabled: true, range: modes.tremorsense });
     }
 
-    // Update?
-    if (Object.keys(updates).length > 0) {
-      token.updateSource(updates);
+    // Note: At the moment (10.288) `updateSource` doesn't return the correct diff (#8503).
+    // So we need to diff `updates` with the source data ourselves until it's fixed.
+    const changes = diffObject(token.toObject(), updates);
+    if (!isEmpty(changes)) {
+      token.updateSource(changes);
       madeUpdates = true;
     }
   }

--- a/script.js
+++ b/script.js
@@ -157,8 +157,22 @@ function updateTokens(actor, { force = false } = {}) {
     .reduce((entries, [sense, range]) => ({ ...entries, [sense]: range }), {});
 
   // Could use a better check than a localization-unfriendly label
-  if (actor.effects.some((e) => e.label === "Devil's Sight" && !e.disabled && !e.isSuppressed)) {
-    modes.devilsSight = 120;
+  for (const effect of actor.effects) {
+    if (effect.disabled || effect.isSuppressed) continue;
+    switch (effect.label) {
+      case "Devil's Sight":
+        modes.devilsSight = 120;
+        break;
+      case "See Invisibility":
+        modes.seeInvisibility = 10000;
+        break;
+      case "Echolocation":
+        if (modes.blindsight) {
+          modes.echolocation = modes.blindsight;
+          delete modes.blindsight;
+        }
+        break;
+    }
   }
 
   let madeUpdates = false;
@@ -188,12 +202,6 @@ function updateTokens(actor, { force = false } = {}) {
       updates.detectionModes.push({ id: "devilsSight", enabled: true, range: modes.devilsSight });
     }
 
-    // Blindsight
-    if (modes.blindsight) {
-      updates.detectionModes ??= [];
-      updates.detectionModes.push({ id: "blindsight", enabled: true, range: modes.blindsight });
-    }
-
     // Truesight
     if (modes.truesight && sight.visionMode !== "devilsSight") {
       const defaults = CONFIG.Canvas.visionModes.devilsSight.vision.defaults;
@@ -201,6 +209,23 @@ function updateTokens(actor, { force = false } = {}) {
       updates.sight = { visionMode: "devilsSight", ...defaults, range };
       updates.detectionModes ??= [];
       updates.detectionModes.push({ id: "seeAll", enabled: true, range: modes.truesight });
+    }
+
+    // See Invisibility
+    if (modes.seeInvisibility) {
+      updates.detectionModes.push({ id: "seeInvisibility", enabled: true, range: modes.seeInvisibility });
+    }
+
+    // Blindsight
+    if (modes.blindsight) {
+      updates.detectionModes ??= [];
+      updates.detectionModes.push({ id: "blindsight", enabled: true, range: modes.blindsight });
+    }
+
+    // Echolocation
+    if (modes.echolocation) {
+      updates.detectionModes ??= [];
+      updates.detectionModes.push({ id: "echolocation", enabled: true, range: modes.echolocation });
     }
 
     // Tremorsense

--- a/script.js
+++ b/script.js
@@ -105,6 +105,34 @@ Hooks.on("updateToken", (token, changes, context, userId) => {
   }
 });
 
+Hooks.on("renderTokenConfig", (sheet, html) => {
+  if (!game.settings.get("adequate-vision", "linkActorSenses")) return;
+  // Disable input fields that are automatically managed
+  html[0].querySelectorAll(`
+    [name="sight.range"],
+    [name="sight.visionMode"],
+    [name="sight.brightness"],
+    [name="sight.saturation"],
+    [name="sight.contrast"],
+    [name^="detectionModes."]`)
+    .forEach((e) => {
+      e.disabled = true;
+
+      if (e.name.startsWith("sight.")) {
+        e.dataset.tooltip = "Managed by Adequate Vision";
+        e.dataset.tooltipDirection = "LEFT";
+      }
+
+      if (e.type === "range") {
+        e.style.filter = "grayscale(1.0) opacity(0.33)";
+        e.parentNode.querySelector(`.range-value`).style.filter = "opacity(0.67)";
+      }
+    });
+  // Remove the buttons to add/remove detection modes
+  html[0].querySelectorAll(`.detection-mode-controls`)
+    .forEach((e) => e.remove());
+});
+
 function onReady() {
   const tokens = canvas.scene?.tokens.contents ?? [];
   const actors = new Set(tokens.flatMap((t) => t.actor ?? []));


### PR DESCRIPTION
- Input fields that are automatically managed are now disabled if *Linked Actor Senses* is enabled.
- Renamed *Feel Tremor* and *See All* modes to *Tremorsense* and *Truesight*.
- If the actor has an effect with a label that matches *See Invisibility* or *Echolocation*, the token gets the corresponding detection mode; this allows the user to actually use those modes with *Linked Actor Senses* enabled.
- ~~Improved vision/detection mode management. The updates weren't applied correctly in come case before this change.~~ (→ #23)
