### PR TITLE
Disable input fields that are managed automatically

### DIFF
--- a/script.js
+++ b/script.js
@@ -105,6 +105,34 @@ Hooks.on("updateToken", (token, changes, context, userId) => {
   }
 });
 
+Hooks.on("renderTokenConfig", (sheet, html) => {
+  if (!game.settings.get("adequate-vision", "linkActorSenses")) return;
+  // Disable input fields that are automatically managed
+  html[0].querySelectorAll(`
+    [name="sight.range"],
+    [name="sight.visionMode"],
+    [name="sight.brightness"],
+    [name="sight.saturation"],
+    [name="sight.contrast"],
+    [name^="detectionModes."]`)
+    .forEach((e) => {
+      e.disabled = true;
+
+      if (e.name.startsWith("sight.")) {
+        e.dataset.tooltip = "Managed by Adequate Vision";
+        e.dataset.tooltipDirection = "LEFT";
+      }
+
+      if (e.type === "range") {
+        e.style.filter = "grayscale(1.0) opacity(0.33)";
+        e.parentNode.querySelector(`.range-value`).style.filter = "opacity(0.67)";
+      }
+    });
+  // Remove the buttons to add/remove detection modes
+  html[0].querySelectorAll(`.detection-mode-controls`)
+    .forEach((e) => e.remove());
+});
+
 function onReady() {
   const tokens = canvas.scene?.tokens.contents ?? [];
   const actors = new Set(tokens.flatMap((t) => t.actor ?? []));


### PR DESCRIPTION
Input fields that are automatically managed and cannot be configured by the user are now disabled if Linked Actor Senses is enabled. Hovering over the disabled input fields shows a tooltip: Managed by Adequate Vision.

![image](https://user-images.githubusercontent.com/31905376/203858820-a0301192-4d0f-48be-ba5a-ab88346a449f.png)
