### PR TITLE
Don't disable input fields if the actor is a vehicle

### DIFF
--- a/script.js
+++ b/script.js
@@ -105,7 +105,8 @@ Hooks.on("updateToken", (token, changes, context, userId) => {
 });
 
 Hooks.on("renderTokenConfig", (sheet, html) => {
-  if (!game.settings.get("adequate-vision", "linkActorSenses")) return;
+  if (!(game.settings.get("adequate-vision", "linkActorSenses")
+    && ["character", "npc"].includes(sheet.object.actor?.type))) return;
   // Disable input fields that are automatically managed
   html[0]
     .querySelectorAll(


### PR DESCRIPTION
Only disable the input fields if the actor is a PC or NPC. Other actor types are not automatically managed.